### PR TITLE
Improve dashboard controls and navigation

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -15,16 +15,22 @@
       <div class="apikey"><label>API Key <input id="apiKey" type="password" placeholder="DEVKEY123"></label><button id="saveKey" class="ghost">Guardar</button></div>
     </div>
   </header>
-  <nav class="tabs glass">
-    <button data-tab="dash" class="active">Dashboard</button>
-    <button data-tab="manual">Manual</button>
-    <button data-tab="auto">Automático</button>
-    <button data-tab="calib">Calibración</button>
-    <button data-tab="profiles">Perfiles</button>
-    <button data-tab="history">Gráficas</button>
-    <button data-tab="boards">Equipos</button>
-    <button data-tab="config">Config</button>
-    <button data-tab="events">Eventos</button>
+  <nav class="tabs glass" aria-label="Secciones principales">
+    <button id="tabToggle" class="tab-toggle pill" aria-haspopup="true" aria-expanded="false">
+      <span id="tabToggleLabel">Dashboard</span>
+      <span class="chevron">▾</span>
+    </button>
+    <div class="tab-menu" role="menu">
+      <button data-tab="dash" class="active" role="menuitem">Dashboard</button>
+      <button data-tab="manual" role="menuitem">Manual</button>
+      <button data-tab="auto" role="menuitem">Automático</button>
+      <button data-tab="calib" role="menuitem">Calibración</button>
+      <button data-tab="profiles" role="menuitem">Perfiles</button>
+      <button data-tab="history" role="menuitem">Gráficas</button>
+      <button data-tab="boards" role="menuitem">Equipos</button>
+      <button data-tab="config" role="menuitem">Config</button>
+      <button data-tab="events" role="menuitem">Eventos</button>
+    </div>
   </nav>
 
   <section id="dash" class="tab active">
@@ -45,6 +51,14 @@
         <li><span>Pulsos</span><b id="pulses">--</b></li>
         <li><span>Tiempo marcha</span><b id="runtime">--</b></li>
       </ul></div>
+      <div class="card glass actions-card">
+        <h3>Acciones rápidas</h3>
+        <div class="quick-actions" id="dashActions">
+          <button id="dashAutoToggle" class="pill wide">Iniciar automático</button>
+          <button id="dashManualToggle" class="pill ghost wide">Encender bomba</button>
+        </div>
+        <p class="hint">Controla el modo activo directamente desde el Dashboard.</p>
+      </div>
       <div class="card glass"><h3>Aprendizaje</h3><ul class="kv">
         <li><span>EMA ciclo</span><b id="emaRun">--</b> s</li>
         <li><span>Pendiente</span><b id="slope">--</b> %/s</li>

--- a/webui/style.css
+++ b/webui/style.css
@@ -7,10 +7,16 @@ header{display:flex;justify-content:space-between;align-items:center;gap:12px;fl
 .apikey label{display:flex;align-items:center;gap:8px;flex:1 1 200px;min-width:0}
 .apikey input{flex:1 1 auto;min-width:120px}
 .apikey button{flex:0 0 auto}
-.tabs{display:flex;flex-wrap:wrap;gap:8px;padding:12px 16px;border-bottom:1px solid var(--border);overflow-x:auto;scrollbar-width:thin}
-.tabs button{flex:1 1 140px;min-width:120px;background:radial-gradient(120% 120% at 50% 15%,rgba(255,255,255,.08),rgba(0,0,0,0));color:var(--ink);border:1px solid color-mix(in oklab,var(--accent),var(--border) 70%);padding:10px 16px;border-radius:999px;cursor:pointer;box-shadow:0 12px 30px -20px var(--accent);transition:transform .3s ease,box-shadow .3s ease,background .3s ease,border-color .3s ease}
-.tabs button:hover{transform:translateY(-2px);box-shadow:0 18px 40px -20px var(--accent);background:radial-gradient(120% 120% at 50% 15%,rgba(255,255,255,.16),rgba(0,0,0,0))}
-.tabs .active{background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,0));border-color:color-mix(in oklab, var(--accent), var(--border) 70%)}
+.tabs{position:relative;display:flex;flex-direction:column;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border)}
+.tab-toggle{display:flex;align-items:center;justify-content:space-between;background:linear-gradient(135deg,color-mix(in oklab,var(--bg2),rgba(0,179,255,.18) 25%),color-mix(in oklab,var(--bg2),rgba(171,92,255,.12) 35%));border-radius:999px;border:1px solid color-mix(in oklab,var(--accent),var(--border) 70%);box-shadow:0 16px 34px -26px var(--accent);font-weight:600;letter-spacing:.02em;padding:12px 18px;cursor:pointer;transition:transform .3s ease,box-shadow .3s ease,border-color .3s ease,background .3s ease}
+.tab-toggle:hover{transform:translateY(-2px);box-shadow:0 22px 46px -26px rgba(0,179,255,.75);border-color:color-mix(in oklab,var(--accent),var(--border) 55%)}
+.tab-toggle .chevron{transition:transform .25s ease}
+.tabs.open .tab-toggle .chevron{transform:rotate(180deg)}
+.tab-menu{display:none;position:absolute;left:16px;right:16px;top:calc(100% - 4px);padding:14px;background:rgba(8,12,18,.96);backdrop-filter:blur(12px);border:1px solid var(--border);border-radius:18px;box-shadow:0 32px 68px -28px rgba(2,10,20,.65);z-index:30;flex-direction:column;gap:10px}
+.tabs.open .tab-menu{display:flex}
+.tab-menu button{background:radial-gradient(120% 120% at 50% 12%,rgba(255,255,255,.08),rgba(0,0,0,0));color:var(--ink);border:1px solid color-mix(in oklab,var(--accent),var(--border) 70%);padding:11px 16px;border-radius:999px;cursor:pointer;box-shadow:0 12px 30px -22px var(--accent);transition:transform .3s ease,box-shadow .3s ease,background .3s ease,border-color .3s ease;text-align:left;font-weight:600;letter-spacing:.01em}
+.tab-menu button:hover{transform:translateY(-2px);box-shadow:0 18px 40px -20px var(--accent);background:radial-gradient(120% 120% at 50% 15%,rgba(255,255,255,.16),rgba(0,0,0,0))}
+.tab-menu .active{background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.02));border-color:color-mix(in oklab,var(--accent),var(--border) 65%)}
 .tab{display:none;padding:16px}.tab.active{display:block}
 .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:16px}
 .card{background:rgba(20,26,38,.6);border:1px solid var(--border);border-radius:16px;box-shadow:0 10px 26px rgba(0,0,0,.35);padding:16px;min-width:0}
@@ -52,6 +58,11 @@ button.wide{width:100%}
 .wsurl{font-family:ui-monospace,Consolas,monospace;font-size:12px;word-break:break-all;color:#a8c7ff;background:rgba(0,0,0,.25);padding:6px;border-radius:8px;border:1px dashed var(--border)}
 .hint{color:var(--muted);font-size:12px}
 #toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);min-width:240px;max-width:92vw;background:rgba(0,0,0,.5);border:1px solid var(--border);padding:12px;border-radius:12px;opacity:0;transition:.25s}#toast.show{opacity:1;transform:translateX(-50%) translateY(-6px)}
+.quick-actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:8px}
+.quick-actions button{flex:1 1 200px;min-width:160px}
+.quick-actions button.on{background:linear-gradient(135deg,color-mix(in oklab,var(--accent),rgba(255,255,255,.08) 35%),rgba(0,0,0,.1));border-color:color-mix(in oklab,var(--accent),var(--border) 45%);box-shadow:0 24px 54px -28px color-mix(in oklab,var(--accent),transparent 20%)}
+.quick-actions button[disabled]{opacity:.55;cursor:not-allowed;box-shadow:none}
+.hidden{display:none!important}
 
 
 /* WiFi bars */
@@ -82,23 +93,23 @@ button.wide{width:100%}
 .accent{display:flex;gap:8px;flex-wrap:wrap}
 
 @media (max-width:960px){
-  .tabs button{flex:1 1 calc(33.33% - 12px)}
+  .tab-menu{left:12px;right:12px}
 }
 
 @media (max-width:720px){
   header{flex-direction:column;align-items:flex-start}
   .controls{width:100%;justify-content:flex-start}
-  .tabs button{flex:1 1 calc(50% - 12px);min-width:0}
   .apikey{width:100%}
   .apikey button{flex:1 1 140px}
+  .tab-menu{left:10px;right:10px}
 }
 
 @media (max-width:520px){
   .controls{flex-direction:column;align-items:stretch}
   .controls .accent{order:1}
   .apikey{order:2}
-  .tabs{gap:6px}
-  .tabs button{flex:1 1 100%}
+  .tabs{gap:10px}
+  .tab-menu{left:8px;right:8px}
   .row>*,.row>label{flex:1 1 100%}
   .manual-controls .knob{min-width:160px}
 }


### PR DESCRIPTION
## Summary
- replace the horizontal tab bar with a dropdown-style navigation menu that keeps the active tab label visible
- add quick action controls on the dashboard to toggle automatic mode or manual pump power without leaving the tab
- update dashboard refresh logic and styling to drive the new controls and dropdown interactions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca2369fdec832ca10ede47f80e0a74