### PR TITLE
Improve header and API key layout on mobile

### DIFF
--- a/webui/style.css
+++ b/webui/style.css
@@ -1,12 +1,16 @@
 :root{--bg:#0e1117;--bg2:#10151d;--ink:#e6edf3;--muted:#93a1b3;--card:#121826;--border:#1c2634;--accent:#00b3ff;--accent-2:#2bd97c;--danger:#ff4d4f}
 *{box-sizing:border-box}html,body{margin:0;background:linear-gradient(180deg,#0b0e13,#0c1017 40%,#0d111a);color:var(--ink);font-family:system-ui,Segoe UI,Roboto,Arial}
-header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;padding:10px 16px;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(0,0,0,.2);backdrop-filter:blur(8px)}
+header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;padding:14px 18px;border-bottom:1px solid color-mix(in oklab,var(--border),transparent 20%);position:sticky;top:0;background:linear-gradient(135deg,rgba(16,20,30,.9),rgba(10,14,22,.72));backdrop-filter:blur(12px);box-shadow:0 18px 28px -24px rgba(0,0,0,.55);z-index:20}
 .brand{flex:1 1 220px}
-.controls{display:flex;align-items:center;justify-content:flex-end;gap:12px;flex:2 1 320px;flex-wrap:wrap}
-.apikey{display:flex;flex-wrap:wrap;align-items:center;gap:8px}
-.apikey label{display:flex;align-items:center;gap:8px;flex:1 1 200px;min-width:0}
-.apikey input{flex:1 1 auto;min-width:120px}
-.apikey button{flex:0 0 auto}
+.brand h1{margin:0;font-size:1.35rem;line-height:1.2;letter-spacing:.01em;display:flex;flex-direction:column;color:var(--ink)}
+.brand h1 small{font-size:.75rem;font-weight:500;color:var(--muted);letter-spacing:.18em;text-transform:uppercase;margin-top:4px}
+.controls{display:flex;align-items:stretch;justify-content:flex-end;gap:12px;flex:2 1 320px;flex-wrap:wrap;background:rgba(15,21,32,.65);border:1px solid color-mix(in oklab,var(--border),transparent 35%);border-radius:18px;padding:10px 12px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);backdrop-filter:blur(8px)}
+.controls .swatch{box-shadow:none;border:1px solid color-mix(in oklab,var(--border),transparent 50%)}
+.apikey{display:flex;flex-wrap:wrap;align-items:center;gap:10px;background:rgba(11,16,26,.72);border:1px solid color-mix(in oklab,var(--border),transparent 30%);border-radius:14px;padding:6px 10px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.03)}
+.apikey label{display:flex;align-items:center;gap:10px;flex:1 1 200px;min-width:0;font-size:.82rem;text-transform:uppercase;letter-spacing:.15em;color:color-mix(in oklab,var(--muted),rgba(255,255,255,.2) 40%)}
+.apikey input{flex:1 1 auto;min-width:140px;padding:10px 12px;border-radius:12px;background:color-mix(in oklab,var(--bg2),rgba(255,255,255,.08));border-color:color-mix(in oklab,var(--border),transparent 40%);box-shadow:0 8px 18px -14px rgba(0,0,0,.8)}
+.apikey input::placeholder{color:color-mix(in oklab,var(--muted),rgba(255,255,255,.3) 45%)}
+.apikey button{flex:0 0 auto;padding:10px 16px}
 .tabs{position:relative;display:flex;flex-direction:column;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border)}
 .tab-toggle{display:flex;align-items:center;justify-content:space-between;background:linear-gradient(135deg,color-mix(in oklab,var(--bg2),rgba(0,179,255,.18) 25%),color-mix(in oklab,var(--bg2),rgba(171,92,255,.12) 35%));border-radius:999px;border:1px solid color-mix(in oklab,var(--accent),var(--border) 70%);box-shadow:0 16px 34px -26px var(--accent);font-weight:600;letter-spacing:.02em;padding:12px 18px;cursor:pointer;transition:transform .3s ease,box-shadow .3s ease,border-color .3s ease,background .3s ease}
 .tab-toggle:hover{transform:translateY(-2px);box-shadow:0 22px 46px -26px rgba(0,179,255,.75);border-color:color-mix(in oklab,var(--accent),var(--border) 55%)}
@@ -97,17 +101,18 @@ button.wide{width:100%}
 }
 
 @media (max-width:720px){
-  header{flex-direction:column;align-items:flex-start}
-  .controls{width:100%;justify-content:flex-start}
+  header{flex-direction:column;align-items:stretch;gap:16px;padding:16px 14px}
+  .brand h1{align-items:flex-start}
+  .controls{width:100%;justify-content:flex-start;padding:12px 14px}
   .apikey{width:100%}
   .apikey button{flex:1 1 140px}
   .tab-menu{left:10px;right:10px}
 }
 
 @media (max-width:520px){
-  .controls{flex-direction:column;align-items:stretch}
-  .controls .accent{order:1}
-  .apikey{order:2}
+  .controls{flex-direction:column;align-items:stretch;padding:14px}
+  .controls .accent{order:1;justify-content:space-between;width:100%}
+  .apikey{order:2;padding:12px}
   .tabs{gap:10px}
   .tab-menu{left:8px;right:8px}
   .row>*,.row>label{flex:1 1 100%}


### PR DESCRIPTION
## Summary
- apply a translucent gradient and spacing adjustments to the header for better contrast on mobile
- restyle the API key controls with glassmorphism accents and responsive tweaks so they feel lighter on dark backgrounds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca284dc178832c808b956b5dcc2b06