### PR TITLE
Make header controls collapsible on mobile

### DIFF
--- a/webui/app.js
+++ b/webui/app.js
@@ -122,6 +122,30 @@ function bind(){
   $('#apiKey').value=API.key;
   $('#saveKey').addEventListener('click',()=>{API.key=$('#apiKey').value.trim(); localStorage.setItem('apiKey',API.key); toast('API Key guardada')});
 
+  const headerEl=$('#app > header');
+  const controlsToggle=$('#controlsToggle');
+  const controlsLabel=controlsToggle?.querySelector('.label');
+  const controlsChevron=controlsToggle?.querySelector('.chevron');
+  const setCollapsed=collapsed=>{
+    if(!headerEl) return;
+    headerEl.classList.toggle('collapsed',collapsed);
+    if(controlsToggle){
+      controlsToggle.setAttribute('aria-expanded',collapsed?'false':'true');
+      if(controlsLabel) controlsLabel.textContent=collapsed?'Mostrar panel':'Ocultar panel';
+      if(controlsChevron) controlsChevron.textContent=collapsed?'▾':'▴';
+    }
+  };
+  if(controlsToggle && headerEl){
+    controlsToggle.addEventListener('click',()=>{
+      const collapsed=!headerEl.classList.contains('collapsed');
+      setCollapsed(collapsed);
+    });
+    const mq=window.matchMedia('(max-width:720px)');
+    const applyResponsive=()=>setCollapsed(mq.matches);
+    applyResponsive();
+    mq.addEventListener('change',applyResponsive);
+  }
+
   const nav=$('#app nav.tabs');
   const tabToggle=$('#tabToggle');
   const tabLabel=$('#tabToggleLabel');

--- a/webui/index.html
+++ b/webui/index.html
@@ -4,7 +4,11 @@
 <div id="app" class="theme-dark">
   <header>
     <div class="brand"><h1>TanqueNivel Industrial <small>UX13</small></h1></div>
-    <div class="controls">
+    <button id="controlsToggle" type="button" class="pill ghost controls-toggle" aria-expanded="true" aria-controls="topControls">
+      <span class="label">Ocultar panel</span>
+      <span class="chevron">▴</span>
+    </button>
+    <div class="controls" id="topControls">
       <div class="accent">
         <button class="swatch" data-accent="#00b3ff" style="--c:#00b3ff"></button>
         <button class="swatch" data-accent="#2bd97c" style="--c:#2bd97c"></button>

--- a/webui/style.css
+++ b/webui/style.css
@@ -1,6 +1,9 @@
 :root{--bg:#0e1117;--bg2:#10151d;--ink:#e6edf3;--muted:#93a1b3;--card:#121826;--border:#1c2634;--accent:#00b3ff;--accent-2:#2bd97c;--danger:#ff4d4f}
 *{box-sizing:border-box}html,body{margin:0;background:linear-gradient(180deg,#0b0e13,#0c1017 40%,#0d111a);color:var(--ink);font-family:system-ui,Segoe UI,Roboto,Arial}
 header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;padding:14px 18px;border-bottom:1px solid color-mix(in oklab,var(--border),transparent 20%);position:sticky;top:0;background:linear-gradient(135deg,rgba(16,20,30,.9),rgba(10,14,22,.72));backdrop-filter:blur(12px);box-shadow:0 18px 28px -24px rgba(0,0,0,.55);z-index:20}
+header.collapsed .controls{display:none}
+.controls-toggle{display:none;align-items:center;gap:10px;font-size:.8rem;letter-spacing:.12em;text-transform:uppercase;padding:8px 14px}
+.controls-toggle .chevron{font-size:.95rem}
 .brand{flex:1 1 220px}
 .brand h1{margin:0;font-size:1.35rem;line-height:1.2;letter-spacing:.01em;display:flex;flex-direction:column;color:var(--ink)}
 .brand h1 small{font-size:.75rem;font-weight:500;color:var(--muted);letter-spacing:.18em;text-transform:uppercase;margin-top:4px}
@@ -103,6 +106,8 @@ button.wide{width:100%}
 @media (max-width:720px){
   header{flex-direction:column;align-items:stretch;gap:16px;padding:16px 14px}
   .brand h1{align-items:flex-start}
+  .controls-toggle{display:inline-flex;align-self:flex-start}
+  header.collapsed .controls-toggle{margin-bottom:0}
   .controls{width:100%;justify-content:flex-start;padding:12px 14px}
   .apikey{width:100%}
   .apikey button{flex:1 1 140px}


### PR DESCRIPTION
## Summary
- add a toggle button in the header to collapse the API/tema controls
- hide the header controls by default on small screens and style the toggle button
- wire up responsive logic so the controls can be shown or hidden as needed

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca2b820340832caddd6778155dde49