### PR TITLE
Ajusta panel superior en móviles

### DIFF
--- a/webui/app.js
+++ b/webui/app.js
@@ -126,13 +126,17 @@ function bind(){
   const controlsToggle=$('#controlsToggle');
   const controlsLabel=controlsToggle?.querySelector('.label');
   const controlsChevron=controlsToggle?.querySelector('.chevron');
-  const setCollapsed=collapsed=>{
+  const setCollapsed=(collapsed,{scroll=true}={})=>{
     if(!headerEl) return;
     headerEl.classList.toggle('collapsed',collapsed);
+    headerEl.classList.toggle('expanded',!collapsed);
     if(controlsToggle){
       controlsToggle.setAttribute('aria-expanded',collapsed?'false':'true');
       if(controlsLabel) controlsLabel.textContent=collapsed?'Mostrar panel':'Ocultar panel';
       if(controlsChevron) controlsChevron.textContent=collapsed?'▾':'▴';
+    }
+    if(!collapsed && scroll){
+      requestAnimationFrame(()=>headerEl.scrollIntoView({behavior:'smooth',block:'start'}));
     }
   };
   if(controlsToggle && headerEl){
@@ -141,7 +145,7 @@ function bind(){
       setCollapsed(collapsed);
     });
     const mq=window.matchMedia('(max-width:720px)');
-    const applyResponsive=()=>setCollapsed(mq.matches);
+    const applyResponsive=()=>setCollapsed(mq.matches,{scroll:false});
     applyResponsive();
     mq.addEventListener('change',applyResponsive);
   }

--- a/webui/style.css
+++ b/webui/style.css
@@ -108,6 +108,8 @@ button.wide{width:100%}
   .brand h1{align-items:flex-start}
   .controls-toggle{display:inline-flex;align-self:flex-start}
   header.collapsed .controls-toggle{margin-bottom:0}
+  header.expanded{position:static}
+  header.expanded .controls{max-height:60vh;overflow:auto;-webkit-overflow-scrolling:touch}
   .controls{width:100%;justify-content:flex-start;padding:12px 14px}
   .apikey{width:100%}
   .apikey button{flex:1 1 140px}


### PR DESCRIPTION
## Summary
- evita que el panel superior quede fijo ocupando la pantalla completa en móviles
- desplaza automáticamente el encabezado al abrir el panel y permite hacer scroll dentro de los controles

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ca2d7897f4832ca0cf9d2e280dc52a