### PR TITLE
Fix UART selection for ESP32-C3 sensors

### DIFF
--- a/firmware/sensor_common.h
+++ b/firmware/sensor_common.h
@@ -15,7 +15,11 @@ const char* BOARD_TOKEN = "test_ws_board_2025_ABCDEF";
 
 const int RX_PIN = 16;
 const int TX_PIN = 17;
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+HardwareSerial& US = Serial1;
+#else
 HardwareSerial& US = Serial2;
+#endif
 
 WebSocketsClient ws;
 uint32_t last_send_ms = 0;


### PR DESCRIPTION
## Summary
- select Serial1 instead of Serial2 when building for ESP32-C3 targets so the firmware compiles on that board family

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca3c0dc70c832ca5b248aa6aa4e795