### PR TITLE
Ensure sensors resend hello after websocket reconnect

### DIFF
--- a/firmware/Sensor_TANQUE_ESP32.ino
+++ b/firmware/Sensor_TANQUE_ESP32.ino
@@ -9,8 +9,7 @@ void setup(){
   US.begin(9600, SERIAL_8N1, RX_PIN, TX_PIN);
   Serial.println("[US] Serial interface initialized");
   ensureWiFi();
-  wsConnect(BOARD_ID);
-  hello(BOARD_ID, "DYP-A01 TANQUE");
+  wsConnect(BOARD_ID, "DYP-A01 TANQUE");
 }
 void loop(){
   ws.loop();
@@ -29,8 +28,16 @@ void loop(){
   if(millis() - last_send_ms >= 1000){
     if(wCount > 0){
       float filt = filteredValue();
-      sendSample(SENSOR_ID, filt);
-      Serial.printf("[DATA] Sent filtered level: %.1f mm\n", filt);
+      if(wsReadyForSamples){
+        sendSample(SENSOR_ID, filt);
+        Serial.printf("[DATA] Sent filtered level: %.1f mm\n", filt);
+      } else {
+        static uint32_t lastHandshakeLog = 0;
+        if(millis() - lastHandshakeLog > 5000){
+          Serial.println("[WS] Waiting for handshake before sending samples");
+          lastHandshakeLog = millis();
+        }
+      }
     } else {
       Serial.println("[DATA] Waiting for valid sensor samples before reporting");
     }

--- a/firmware/Sensor_TOLVA_ESP32/Sensor_TOLVA_ESP32.ino
+++ b/firmware/Sensor_TOLVA_ESP32/Sensor_TOLVA_ESP32.ino
@@ -9,8 +9,7 @@ void setup(){
   US.begin(9600, SERIAL_8N1, RX_PIN, TX_PIN);
   Serial.println("[US] Serial interface initialized");
   ensureWiFi();
-  wsConnect(BOARD_ID);
-  hello(BOARD_ID, "DYP-A01 TOLVA");
+  wsConnect(BOARD_ID, "DYP-A01 TOLVA");
 }
 void loop(){
   ws.loop();
@@ -29,8 +28,16 @@ void loop(){
   if(millis() - last_send_ms >= 1000){
     if(wCount > 0){
       float filt = filteredValue();
-      sendSample(SENSOR_ID, filt);
-      Serial.printf("[DATA] Sent filtered level: %.1f mm\n", filt);
+      if(wsReadyForSamples){
+        sendSample(SENSOR_ID, filt);
+        Serial.printf("[DATA] Sent filtered level: %.1f mm\n", filt);
+      } else {
+        static uint32_t lastHandshakeLog = 0;
+        if(millis() - lastHandshakeLog > 5000){
+          Serial.println("[WS] Waiting for handshake before sending samples");
+          lastHandshakeLog = millis();
+        }
+      }
     } else {
       Serial.println("[DATA] Waiting for valid sensor samples before reporting");
     }

--- a/firmware/sensor_common.h
+++ b/firmware/sensor_common.h
@@ -26,6 +26,10 @@ WebSocketsClient ws;
 uint32_t last_send_ms = 0;
 const int WN = 7; float windowVals[WN]; int wCount=0; float last_mm = 0;
 
+const char* wsBoardId = nullptr;
+const char* wsBoardName = nullptr;
+bool wsReadyForSamples = false;
+
 // --- Advanced filtering configuration ---
 const float MIN_LEVEL_MM = 50.0f;
 const float MAX_LEVEL_MM = 4500.0f;
@@ -77,17 +81,26 @@ void ensureWiFi(){
 }
 void wsSendJson(DynamicJsonDocument &doc){ String out; serializeJson(doc, out); ws.sendTXT(out); }
 void hello(const char* id, const char* name){ DynamicJsonDocument d(256); d["type"]="hello"; d["id"]=id; d["kind"]="SENSOR"; d["name"]=name; d["token"]=BOARD_TOKEN; d["fw"]=FW_VERSION; d["mac"]=WiFi.macAddress(); d["rssi"]=WiFi.RSSI(); d["uptime_s"]=(millis()-boot_ms)/1000; wsSendJson(d); }
-void sendSample(const char* sensor, float mm){ DynamicJsonDocument d(256); d["type"]="sensor"; d["sensor_id"]=sensor; d["mm"]=mm; d["rssi"]=WiFi.RSSI(); d["uptime_s"]=(millis()-boot_ms)/1000; wsSendJson(d); }
+void sendSample(const char* sensor, float mm){ if(!wsReadyForSamples){ return; } DynamicJsonDocument d(256); d["type"]="sensor"; d["sensor_id"]=sensor; d["mm"]=mm; d["rssi"]=WiFi.RSSI(); d["uptime_s"]=(millis()-boot_ms)/1000; wsSendJson(d); }
 void onWsEvent(WStype_t type, uint8_t * payload, size_t length){
   switch(type){
     case WStype_CONNECTED:
       Serial.println("[WS] Connected to server");
+      wsReadyForSamples = false;
+      if(wsBoardId != nullptr && wsBoardName != nullptr){
+        hello(wsBoardId, wsBoardName);
+        wsReadyForSamples = true;
+      } else {
+        Serial.println("[WS] Board identity not set, cannot send hello");
+      }
       break;
     case WStype_DISCONNECTED:
       Serial.println("[WS] Disconnected from server");
+      wsReadyForSamples = false;
       break;
     case WStype_ERROR:
       Serial.println("[WS] Error event received");
+      wsReadyForSamples = false;
       break;
     case WStype_TEXT:
       Serial.printf("[WS] Message: %.*s\n", (int)length, (const char*)payload);
@@ -96,7 +109,7 @@ void onWsEvent(WStype_t type, uint8_t * payload, size_t length){
       break;
   }
 }
-void wsConnect(const char* id){ String path=String("/ws/board/")+id+"?token="+BOARD_TOKEN; ws.begin(WS_HOST, WS_PORT, path.c_str()); ws.onEvent(onWsEvent); ws.setReconnectInterval(2000);
+void wsConnect(const char* id, const char* name){ wsBoardId = id; wsBoardName = name; wsReadyForSamples = false; String path=String("/ws/board/")+id+"?token="+BOARD_TOKEN; ws.begin(WS_HOST, WS_PORT, path.c_str()); ws.onEvent(onWsEvent); ws.setReconnectInterval(2000);
   ws.enableHeartbeat(15000, 3000, 2); }
 
 uint32_t lastSensorRead_ms = 0;


### PR DESCRIPTION
## Summary
- store the board identifier and human-readable name when establishing the websocket connection so they can be reused on reconnect.
- resend the hello message whenever the websocket reports a successful connection before allowing sensor data transmissions.
- gate sample delivery until the handshake completes and log when waiting for it to recover.

## Testing
- not run (firmware changes)


------
https://chatgpt.com/codex/tasks/task_e_68cb0329a640832ca9e0eda6bc8b443a