### PR TITLE
Restore sensor freshness helper for hopper firmware

### DIFF
--- a/firmware/Sensor_TOLVA_ESP32/sensor_common.h
+++ b/firmware/Sensor_TOLVA_ESP32/sensor_common.h
@@ -273,9 +273,6 @@ bool readSensor(float &mm){
     sensorErrorCount = 0;
     return true;
   }
-  if(lastSensorRead_ms == 0){
-    lastSensorRead_ms = millis();
-  }
   if(!sensorWarningPrinted && millis() - lastSensorRead_ms > sensorTimeout_ms){
     Serial.println("[US] No readings received from ultrasonic sensor");
     sensorWarningPrinted = true;
@@ -318,12 +315,19 @@ float filteredValue(){
   }
   return filtered_mm;
 }
+bool sensorDataFresh(uint32_t maxAge_ms){
+  if(lastSensorRead_ms == 0){
+    return false;
+  }
+  return (millis() - lastSensorRead_ms) <= maxAge_ms;
+}
+
 void recoverSensorLink(){
   Serial.println("[US] Attempting to recover ultrasonic sensor link");
   US.end();
   delay(20);
   beginSensorInterface();
-  lastSensorRead_ms = millis();
+  lastSensorRead_ms = 0;
   sensorWarningPrinted = false;
   sensorErrorCount = 0;
 }

--- a/firmware/sensor_common.h
+++ b/firmware/sensor_common.h
@@ -352,9 +352,6 @@ bool readSensor(float &mm){
     return false;
   }
 
-  if(lastSensorRead_ms == 0){
-    lastSensorRead_ms = millis();
-  }
   if(!sensorWarningPrinted && millis() - lastSensorRead_ms > sensorTimeout_ms){
     Serial.println("[US] No readings received from ultrasonic sensor");
     sensorWarningPrinted = true;
@@ -372,6 +369,13 @@ bool readSensor(float &mm){
     resetFilterState();
   }
   return false;
+}
+
+bool sensorDataFresh(uint32_t maxAge_ms){
+  if(lastSensorRead_ms == 0){
+    return false;
+  }
+  return (millis() - lastSensorRead_ms) <= maxAge_ms;
 }
 
 struct WindowStats{
@@ -490,7 +494,7 @@ void recoverSensorLink(){
   beginSensorInterface();
   resetWindow();
   resetFilterState();
-  lastSensorRead_ms = millis();
+  lastSensorRead_ms = 0;
   sensorWarningPrinted = false;
   sensorErrorCount = 0;
 }


### PR DESCRIPTION
## Summary
- add the missing sensor freshness helper used by the hopper sketch to detect stale readings
- avoid marking the last hopper ultrasonic read as fresh when the link is reset so stale filtering works again

## Testing
- not run (firmware-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1bc323c3c832c8c95a796df2a98ba