### PR TITLE
Declare wsSendJson before use

### DIFF
--- a/firmware/Sensor_TOLVA_ESP32/sensor_common.h
+++ b/firmware/Sensor_TOLVA_ESP32/sensor_common.h
@@ -77,6 +77,7 @@ void resetWindow();
 void resetFilterState();
 void beginSensorInterface();
 void triggerSensorPulse();
+void wsSendJson(DynamicJsonDocument &doc);
 
 void publishSensorHealth(SensorHealthState state, const char* reason){
   if(!wsReadyForSamples){

--- a/firmware/sensor_common.h
+++ b/firmware/sensor_common.h
@@ -77,6 +77,7 @@ void resetWindow();
 void resetFilterState();
 void beginSensorInterface();
 void triggerSensorPulse();
+void wsSendJson(DynamicJsonDocument &doc);
 
 void publishSensorHealth(SensorHealthState state, const char* reason){
   if(!wsReadyForSamples){


### PR DESCRIPTION
## Summary
- declare wsSendJson prototype before its first use in sensor_common headers to satisfy the compiler

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1cc5083dc832c92cafb17c7240c45